### PR TITLE
DefaultRoute Change

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -209,7 +209,7 @@ class RouteStore {
     }
 
     routeExists(path: string): boolean {
-        return this.routes.filter((route: Route) => route.path === path).length > 0;
+        return this.routes.filter((route: Route) => route.match()).length > 0;
     }
 }
 


### PR DESCRIPTION
The DefaultRoute seems to always add itself to pages with route parameters because this check doesn't account for the parameters. The route.match function does and should function the same otherwise.