### PR TITLE
Route Exists Short Circuit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export class DefaultRoute {
     }
 
     mount(): Function | null {
-        return !Store.routeExists(location.pathname) ? this.component() : null
+        return !Store.routeExists() ? this.component() : null
     }
 }
 
@@ -208,8 +208,8 @@ class RouteStore {
         this.routes.push(route);
     }
 
-    routeExists(path: string): boolean {
-        return this.routes.filter((route: Route) => route.match()).length > 0;
+    routeExists(): boolean {
+        return this.routes.some((route: Route) => route.match() !== null);
     }
 }
 


### PR DESCRIPTION
Removed unnecessary path parameter and changed to Array.prototype.some for short-circuiting behavior. An alternative to this change would be to add a parameter to Route.match that takes a path (the default is location.pathname).